### PR TITLE
Fixed Number of Mining Techs

### DIFF
--- a/config.js
+++ b/config.js
@@ -29,7 +29,7 @@ const config = {
   },
 
   // Hades Star TechList
-  "hadesTechSize" : {"ships":3,"trade":10,"mining":8,"weapons":5,"shields":7,"support":21},
+  "hadesTechSize" : {"ships":3,"trade":10,"mining":9,"weapons":5,"shields":7,"support":21},
 
   "hadesTech" : {
     "rs": {desc: "Base - RedStar Scanner", group: "base", redditURL: "red_stars", levels: [1,2,20,60,120,250,1000,2000,4000,8000]},


### PR DESCRIPTION
Updated amount of mining tech in "hadesTechSize". This hopefully resolves the error when setting the mining group of techs with mining drone included.

![annotation](https://user-images.githubusercontent.com/11901899/47256883-e4a2b080-d4b0-11e8-90a1-876ffdfd674b.png)

**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**


**Semantic versioning classification:**  
- [x] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
